### PR TITLE
added nyt api call function

### DIFF
--- a/Develop/script.js
+++ b/Develop/script.js
@@ -1,0 +1,29 @@
+//  NYT API KEY: ca099Snk2Kugzxo0Gc84kVoreQgmVbiT
+
+function getNYT() {
+    // TO DO: set year, month, and day variables to the selected value
+    let year = 1970;
+    let month = 12;
+    let day = 15
+    // Searches for headlines labeled as "news" if the search is post-1980 (non archival)
+    if(year < 1981) {
+        newsType = ""
+    } else {
+        newsType = "&facet=true&facet_fields=type_of_material&fq=news"
+    };
+
+    let nytURL = "https://api.nytimes.com/svc/search/v2/articlesearch.json?begin_date=" + year + month + day + "&end_date=" + year + month + day + newsType + "&page=1&sort=relevance&api-key=ca099Snk2Kugzxo0Gc84kVoreQgmVbiT";
+    fetch(nytURL)
+    .then(function (response) {
+        return response.json();
+    })
+    .then(function (data) {
+        console.log(data);
+        for(i = 0; i < 5; i++) {
+            document.querySelector("#headline" + [i + 1]).textContent = data.response.docs[i].headline.main;
+            document.querySelector("#blurb" + [i + 1]).textContent = data.response.docs[i].abstract;
+        }
+    })
+}
+
+// TO DO: add event listener to search button that executes getNYT()

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <div class="nyt" id="nyt">
-        <h1>New York Times Articles from [date]:</h1>
+        <h1 id="title">New York Times Articles from [date]:</h1>
         <div class="story" id="story1">
             <h2 class="headline" id="headline1">Headline</h2>
             <p class="blurb" id="blurb1">blurb</p>
@@ -29,5 +29,6 @@
             <p class="blurb" id="blurb5">blurb</p>
         </div>
     </div>
+    <script src="Develop/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Added a function that calls the New York Times API, pulls front-page headlines from the given date, and displays the first five along with a short abstract on the page. It needs an event listener and code that plugs the date input into the 'year' 'month' and 'day variables.