### PR TITLE
got nyt function fully working

### DIFF
--- a/Develop/script.js
+++ b/Develop/script.js
@@ -4,30 +4,27 @@ let dateInputEl = document.querySelector('#date');
 let headerEl = document.querySelector('#header');
 let titleEl = document.querySelector('#title');
 let newsSection = document.querySelector('#newspaper');
-document.querySelector("#date").value.replaceAll('-', '');
 //  NYT API KEY: ca099Snk2Kugzxo0Gc84kVoreQgmVbiT
 
 function getNYT(event) {
     event.preventDefault();
-    // TO DO: set year, month, and day variables to the selected value
-    let year = '1970';
-    let month = '12';
-    let day = '15';
-    console.log('hello');
+    let urlDate = document.querySelector("#date").value.replaceAll('-', '');
+    // Returns the searched year
+    let searchYear = urlDate.slice(0, 4);
+
     // Searches for headlines labeled as "news" if the search is post-1980 (non archival)
-    if(year < 1981) {
+    if(searchYear < 1981) {
         newsType = ""
     } else {
         newsType = "&facet=true&facet_fields=type_of_material&fq=news"
     };
 
-    let nytURL = "https://api.nytimes.com/svc/search/v2/articlesearch.json?begin_date=" + year + month + day + "&end_date=" + year + month + day + newsType + "&page=1&sort=relevance&api-key=ca099Snk2Kugzxo0Gc84kVoreQgmVbiT";
+    let nytURL = "https://api.nytimes.com/svc/search/v2/articlesearch.json?begin_date=" + urlDate + "&end_date=" + urlDate + newsType + "&page=1&sort=relevance&api-key=ca099Snk2Kugzxo0Gc84kVoreQgmVbiT";
     fetch(nytURL)
     .then(function (response) {
         return response.json();
     })
     .then(function (data) {
-        console.log(data);
         for(i = 0; i < 5; i++) {
             document.querySelector("#headline" + [i + 1]).textContent = data.response.docs[i].headline.main;
             document.querySelector("#blurb" + [i + 1]).textContent = data.response.docs[i].abstract;

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <section id="newspaper" class="hide">
         <div class="nyt" id="nyt">
             <div class="nyt" id="nyt">
-                <h1 id="title">New York Times Articles from [date]:</h1>
+                <h1 id="titleNYT">New York Times Articles from this day:</h1>
             <div class="story" id="story1">
                 <h2 class="headline" id="headline1">Headline</h2>
                 <p class="blurb" id="blurb1">blurb</p>


### PR DESCRIPTION
Moved the method that returns the date in yyyymmdd format into the getNYT function and added it as a variable to the API call, replacing the day, month, and year variables. Also added a variable that slices the date to get just the year, so the API call can check if it's pre-1980 via the searchYear variable and add the 'News' filter query if not.